### PR TITLE
FOGL-7015: Fixed couple of unit tests

### DIFF
--- a/include/python35.h
+++ b/include/python35.h
@@ -59,6 +59,7 @@ class Python35Filter : public FledgeFilter
 			getFiltersPath() const { return m_filtersPath; };
 		bool	setScriptName();
 		bool	configure();
+		bool	initSuccess() { return m_init; }
 		bool	reconfigure(const std::string& newConfig);
 		void	lock() { m_configMutex.lock(); };
 		void	unlock() { m_configMutex.unlock(); };

--- a/tests/test_info.cpp
+++ b/tests/test_info.cpp
@@ -15,7 +15,7 @@ TEST(EXPRESSION_INFO, PluginInfo)
 {
 	PLUGIN_INFORMATION *info = plugin_info();
 	ASSERT_STREQ(info->name, "python35");
-	ASSERT_EQ(info->type, PLUGIN_TYPE_FILTER);
+	ASSERT_STREQ(info->type, PLUGIN_TYPE_FILTER);
 }
 
 TEST(EXPRESSION_INFO, PluginInfoConfigParse)

--- a/tests/test_python35.cpp
+++ b/tests/test_python35.cpp
@@ -9,6 +9,7 @@
 #include <rapidjson/document.h>
 #include <reading.h>
 #include <reading_set.h>
+#include <python35.h>
 
 using namespace std;
 using namespace rapidjson;
@@ -291,7 +292,9 @@ TEST(PYTHON35, IndentError)
 	config->setValue("enable", "true");
 	ReadingSet *outReadings;
 	void *handle = plugin_init(config, &outReadings, Handler);
-	ASSERT_EQ(handle, (void *)NULL);
+	Python35Filter *hndl = (Python35Filter *) handle;
+	// handle is valid but it has not been configured/init properly/completely because of indent error in python script
+	ASSERT_FALSE(hndl && hndl->initSuccess());
 }
 
 #if 0


### PR DESCRIPTION
In "TEST(PYTHON35, IndentError)", there is call to "plugin_init", which further calls "Python35Filter::init()" and that further calls "Python35Filter::configure()". Herein, "PyImport_ImportModule" gets called which fails due to indentation error in provided python script. Back in Python35Filter::init(), "m_init = false" is set, but still the Python35Filter object has been formed and hence "plugin_init" returns a properly formed object even though it's initialization has failed. Back in "TEST(PYTHON35, IndentError)", "ASSERT_EQ(handle, (void *)NULL);" would fail as expected.

Now, in fix, checking whether handle has been initialized properly.

Signed-off-by: Amandeep Singh Arora <aman@dianomic.com>